### PR TITLE
Removed Python-Telegram-bot in setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="isaackeinstein@gmail.com",
     license="MIT",
     packages=["sarufi"],
-    install_requires=["requests", "pyyaml", "python-telegram-bot"],
+    install_requires=["requests", "pyyaml"],
     keywords=[
         "sarufi",
         "Sarufi Python SDK",


### PR DESCRIPTION
As referenced on [Issue](https://github.com/Neurotech-HQ/sarufi-python-sdk/issues/16#issue-1803223513)